### PR TITLE
Fix unused PUSHER_APP_CLUSTER env

### DIFF
--- a/src/server/common/pusher.ts
+++ b/src/server/common/pusher.ts
@@ -4,7 +4,7 @@ export const pusherServerClient = new PusherServer({
   appId: env.PUSHER_APP_ID!,
   key: env.NEXT_PUBLIC_PUSHER_APP_KEY!,
   secret: env.PUSHER_APP_SECRET!,
-  cluster: "us3",
+  cluster: env.NEXT_PUBLIC_PUSHER_APP_CLUSTER!,
   // host: "zback-production.up.railway.app",
   useTLS: true,
 });

--- a/src/server/env-schema.js
+++ b/src/server/env-schema.js
@@ -11,7 +11,7 @@ const envSchema = z.object({
   PUSHER_APP_ID: z.string(),
   NEXT_PUBLIC_PUSHER_APP_KEY: z.string(),
   PUSHER_APP_SECRET: z.string(),
-  PUSHER_APP_CLUSTER: z.string(),
+  NEXT_PUBLIC_PUSHER_APP_CLUSTER: z.string(),
 });
 
 module.exports.envSchema = envSchema;

--- a/src/server/env-schema.js
+++ b/src/server/env-schema.js
@@ -11,7 +11,7 @@ const envSchema = z.object({
   PUSHER_APP_ID: z.string(),
   NEXT_PUBLIC_PUSHER_APP_KEY: z.string(),
   PUSHER_APP_SECRET: z.string(),
-  NEXT_PUBLIC_PUSHER_APP_CLUSTER: z.string(),
+  NEXT_PUBLIC_PUSHER_APP_CLUSTER: z.string().default("us3"),
 });
 
 module.exports.envSchema = envSchema;

--- a/src/utils/pusher.tsx
+++ b/src/utils/pusher.tsx
@@ -8,6 +8,7 @@ import reactZustandCreate from "zustand";
 import vanillaCreate, { StoreApi } from "zustand/vanilla";
 
 const pusher_key = process.env.NEXT_PUBLIC_PUSHER_APP_KEY!;
+const cluster = process.env.NEXT_PUBLIC_PUSHER_APP_CLUSTER!;
 
 interface PusherZustandStore {
   pusherClient: Pusher;
@@ -28,7 +29,7 @@ const createPusherStore = (slug: string, publishPresence?: boolean) => {
     auth: {
       headers: { user_id: randomUserId },
     },
-    cluster: "us3",
+    cluster: cluster,
   });
   const channel = pusherClient.subscribe(slug);
 


### PR DESCRIPTION
Renames the PUSHER_APP_CLUSTER to NEXT_PUBLIC_PUSHER_APP_CLUSTER so the client can access it, started using it in code and set the default value to "us3" so everything should work as before