### PR TITLE
[feat][P-337] Chatbot submission endpoints

### DIFF
--- a/src/pages/api/external/chatbots.tsx
+++ b/src/pages/api/external/chatbots.tsx
@@ -1,0 +1,41 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { pusherServerClient } from "../../../server/common/pusher";
+import { prisma } from "../../../server/db/client";
+
+const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
+  const channelName = req.query["channel"] as string;
+  const question = req.query["q"] as string;
+  // const askerName = req.query["user"] as string;
+
+  if (!question || !channelName) {
+    res.status(400).json({
+      message: "Invalid request",
+    });
+    return;
+  }
+
+  //find user in database
+  const user = await prisma.user.findFirst({
+    where: { name: { equals: channelName } },
+  });
+
+  if (!user) {
+    res.status(400).json({ message: "User not found" });
+    return;
+  }
+
+  // insert question into database
+  await prisma.question.create({
+    data: {
+      body: question,
+      userId: user.id,
+    },
+  });
+
+  // inform client of new question
+  await pusherServerClient.trigger(`user-${user.id}`, "new-question", {});
+
+  res.status(200).end();
+};
+
+export default handleRequest;

--- a/src/pages/api/external/fossabot.tsx
+++ b/src/pages/api/external/fossabot.tsx
@@ -49,14 +49,14 @@ const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
   const question = messageData.message.content.match(/(?<=\s).*/)[0];
 
   // insert question into database
-  prisma.question.create({
+  await prisma.question.create({
     data: {
       body: question,
       userId: user.id,
     },
   });
 
-  res.status(200);
+  res.status(200).end();
 };
 
 export default handleRequest;

--- a/src/pages/api/external/fossabot.tsx
+++ b/src/pages/api/external/fossabot.tsx
@@ -1,0 +1,62 @@
+import { NextApiRequest, NextApiResponse } from "next";
+import { prisma } from "../../../server/db/client";
+
+const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
+  const validateUrl = req.headers["x-fossabot-validateurl"] as string;
+  const channelName = req.headers["x-fossabot-channeldisplayname"] as string;
+
+  if (!validateUrl || !channelName) {
+    res.status(400).json({
+      message: "Invalid request",
+    });
+    return;
+  }
+
+  //find user in database
+  const user = await prisma.user.findFirst({
+    where: { name: { equals: channelName } },
+  });
+
+  if (!user) {
+    res.status(400).json({ message: "User not found" });
+    return;
+  }
+
+  //validate request is coming from fossabot
+  const validateResponse = await fetch(validateUrl);
+
+  if (validateResponse.status !== 200) {
+    res.status(400).json({
+      message: "Failed to validate request.",
+    });
+    return;
+  }
+
+  const messageDataUrl = await validateResponse
+    .json()
+    .then((data) => data.context_url);
+
+  const messageDataResponse = await fetch(messageDataUrl);
+
+  if (messageDataResponse.status !== 200) {
+    res.status(400).json({ message: "Failed to fetch message data" });
+    return;
+  }
+
+  const messageData = await messageDataResponse.json();
+
+  // strip off the command, e.g. !ask
+  const question = messageData.message.content.match(/(?<=\s).*/)[0];
+
+  // insert question into database
+  prisma.question.create({
+    data: {
+      body: question,
+      userId: user.id,
+    },
+  });
+
+  res.status(200);
+};
+
+export default handleRequest;

--- a/src/pages/api/external/fossabot.tsx
+++ b/src/pages/api/external/fossabot.tsx
@@ -1,4 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
+import input from "postcss/lib/input";
+import { pusherServerClient } from "../../../server/common/pusher";
 import { prisma } from "../../../server/db/client";
 
 const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
@@ -55,6 +57,9 @@ const handleRequest = async (req: NextApiRequest, res: NextApiResponse) => {
       userId: user.id,
     },
   });
+
+  // inform client of new question
+  await pusherServerClient.trigger(`user-${user.id}`, "new-question", {});
 
   res.status(200).end();
 };


### PR DESCRIPTION
### To use: 
1. Create a custom command on Fossabot with the response 
   `$(customapi https://ask.ping.gg/api/external/fossabot)`
2. Any messages sent to this command on your channel will be added to your question queue.



Nightbot: 

`$(urlfetch https://ask.ping.gg/api/external/chatbots?q=$(querystring)&channel=$(channel)&user=$(user))`

StreamElements:

`${urlfetch https://ask.ping.gg/api/external/chatbots?channel=${channel}&q=${queryescape ${1:}}&user=${user}}`



### Future improvements:
- Support other chat bots
   - Note that other bots don't offer a way to verify request came from them (maybe add a `key` query param?)
- Maybe have a Ping-hosted chatbot (no reliance on using another chatbot)
- Non-anonymous question submission

